### PR TITLE
Improve NFC scanner design

### DIFF
--- a/src/screens/NfcScannerScreen.tsx
+++ b/src/screens/NfcScannerScreen.tsx
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { CompositeNavigationProp } from '@react-navigation/native';
 import { useNavigation } from '@react-navigation/native';
+import { Feather } from '@expo/vector-icons';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import {
@@ -30,11 +31,11 @@ export default function NfcScannerScreen() {
   const { setHasScanned } = useScan();
   
   const acciones = [
-    { key: 'asistencia',    titulo: 'Ingresar asistencia',  tipo: 'ASISTENCIA' },
-    { key: 'recoleccion',   titulo: 'Ingresar recolección', tipo: 'RECOLECCION' },
-    { key: 'cuadrilla',     titulo: 'Asignar a cuadrilla',   tipo: 'CUADRILLA' },
-    { key: 'registrar',     titulo: 'Registrar usuario',     tipo: 'REGISTRAR' },
-    { key: 'misRegistros',  titulo: 'Mis Registros',         tipo: 'MIS_REGISTROS' as const },
+    { key: 'asistencia',   titulo: 'Ingresar asistencia',  tipo: 'ASISTENCIA',   icon: 'check-circle' },
+    { key: 'recoleccion',  titulo: 'Ingresar recolección', tipo: 'RECOLECCION', icon: 'package' },
+    { key: 'cuadrilla',    titulo: 'Asignar a cuadrilla',  tipo: 'CUADRILLA',   icon: 'users' },
+    { key: 'registrar',    titulo: 'Registrar usuario',    tipo: 'REGISTRAR',   icon: 'user-plus' },
+    { key: 'misRegistros', titulo: 'Mis Registros',        tipo: 'MIS_REGISTROS' as const, icon: 'file-text' },
   ] as const;
 
   const handleScan = async (tipoAccion: typeof acciones[number]['tipo']) => {
@@ -77,13 +78,15 @@ export default function NfcScannerScreen() {
         contentContainerStyle={styles.scrollContainer}
         showsVerticalScrollIndicator={false}
       >
-        {acciones.map(({ key, titulo, tipo }) => (
+        <Text style={styles.title}>Seleccione una acción</Text>
+        {acciones.map(({ key, titulo, tipo, icon }) => (
           <View key={key} style={{ alignItems: 'center', marginVertical: 12 }}>
             <TouchableOpacity
-              style={[styles.card, { width: screenWidth * 0.6 }]}
+              style={[styles.card, { width: screenWidth * 0.8 }]}
               activeOpacity={0.7}
               onPress={() => handleScan(tipo)}
             >
+              <Feather name={icon} size={20} color="#0E110F" style={styles.icon} />
               <Text style={styles.cardButtonText}>{titulo}</Text>
             </TouchableOpacity>
           </View>

--- a/src/screens/TymeEntryScreen.tsx
+++ b/src/screens/TymeEntryScreen.tsx
@@ -31,6 +31,13 @@ type TimeEntryNavProp = NativeStackNavigationProp<HomeStackParamList, 'TimeEntry
 
 const tiposOrder: TipoAsistencia[] = ['entrada', 'salida_colacion', 'entrada_colacion', 'salida'];
 
+const iconMap: Record<TipoAsistencia, React.ComponentProps<typeof Feather>['name']> = {
+  entrada: 'log-in',
+  salida_colacion: 'coffee',
+  entrada_colacion: 'log-in',
+  salida: 'log-out',
+};
+
 export default function TimeEntryScreen() {
   const navigation = useNavigation<TimeEntryNavProp>();
   const { params } = useRoute<TimeEntryRouteProp>();
@@ -152,6 +159,7 @@ export default function TimeEntryScreen() {
           style={[styles.button, !enabled[tipo] && styles.buttonDisabled]}
           disabled={!enabled[tipo]}
           onPress={() => handlePress(tipo)}>
+          <Feather name={iconMap[tipo]} size={20} color="#004D40" style={styles.icon} />
           <Text style={styles.buttonText}>{formatTipo(tipo)}</Text>
         </TouchableOpacity>
       ))}

--- a/src/styles/nfcScannerStyles.ts
+++ b/src/styles/nfcScannerStyles.ts
@@ -15,11 +15,13 @@ export default StyleSheet.create({
     paddingHorizontal: 16,
   },
   card: {
-    // Cada "tarjeta" tendrá un fondo blanco, esquinas redondeadas y sombra ligera
-    backgroundColor: '#A8DEBA',
+    // Cada "tarjeta" tendrá fondo blanco con borde de color para resaltar
+    backgroundColor: '#FFF',
+    borderColor: '#A8DEBA',
+    borderWidth: 1,
     borderRadius: 12,
-    paddingVertical: 20,
-    paddingHorizontal: 16,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
     marginBottom: 16,
 
     // Sombra para iOS
@@ -34,7 +36,9 @@ export default StyleSheet.create({
     // definimos un ancho "máximo" y centramos
     width: '100%',           // Max ancho del card = ancho padre menos paddingHorizontal
     maxWidth: 500,           // Evita que se estire demasiado en tablets o pantallas anchas
-    alignItems: 'center',    // Centrar todo dentro de la tarjeta
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
   },
   cardTitle: {
     fontSize: 18,
@@ -54,6 +58,16 @@ export default StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: '#0E110F',
+    textAlign: 'center',
+  },
+  icon: {
+    marginRight: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 24,
     textAlign: 'center',
   },
 });

--- a/src/styles/nfcScannerStyles.ts
+++ b/src/styles/nfcScannerStyles.ts
@@ -58,7 +58,8 @@ export default StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: '#0E110F',
-    textAlign: 'center',
+    textAlign: 'left',
+    flex: 1,
   },
   icon: {
     marginRight: 12,

--- a/src/styles/tymeEntryStyles.ts
+++ b/src/styles/tymeEntryStyles.ts
@@ -33,7 +33,7 @@ export default StyleSheet.create({
     marginBottom: 24,
   },
   button: {
-    width: '90%',
+    width: '100%',
     maxWidth: 500,
     paddingVertical: 16,
     paddingHorizontal: 20,

--- a/src/styles/tymeEntryStyles.ts
+++ b/src/styles/tymeEntryStyles.ts
@@ -34,11 +34,17 @@ export default StyleSheet.create({
   },
   button: {
     width: '90%',
-    paddingVertical: 14,
-    backgroundColor: '#A8E6CF',
+    maxWidth: 500,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    backgroundColor: '#FFF',
+    borderColor: '#A8E6CF',
+    borderWidth: 1,
     borderRadius: 12,
+    flexDirection: 'row',
     alignItems: 'center',
     marginVertical: 8,
+    justifyContent: 'flex-start',
     ...Platform.select({
       ios: {
         shadowColor: '#000',
@@ -47,16 +53,22 @@ export default StyleSheet.create({
         shadowRadius: 4,
       },
       android: {
-        elevation: 3,
+        elevation: 2,
       },
     }),
   },
   buttonDisabled: {
     backgroundColor: '#E0E0E0',
+    borderColor: '#E0E0E0',
   },
   buttonText: {
     fontSize: 16,
     fontWeight: '600',
     color: '#004D40',
+    flex: 1,
+    textAlign: 'left',
+  },
+  icon: {
+    marginRight: 12,
   },
 });


### PR DESCRIPTION
## Summary
- enhance NFC scanner screen layout with icons and header text
- update NFC scanner styles for modern card look

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcdd758e4832fa78030309094373e