### PR TITLE
Add worker creation screen

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -9,6 +9,7 @@ import TabsNavigator from './TabsNavigator';
 import TransicionScreen from '../screens/TransicionScreen';
 import DetalleTrabajadorScreen from '../screens/DetalleTrabajadorScreen';
 import TimeEntryScreen from '../screens/TymeEntryScreen';
+import CrearTrabajadorScreen from '../screens/CrearTrabajadorScreen';
 import { useAuth } from '../contexts/AuthContext';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -40,6 +41,10 @@ export default function RootNavigator() {
           <Stack.Screen
             name="TimeEntry"
             component={TimeEntryScreen}
+          />
+          <Stack.Screen
+            name="CrearTrabajador"
+            component={CrearTrabajadorScreen}
           />
         </>
       ) : (

--- a/src/navigation/TabsNavigator.tsx
+++ b/src/navigation/TabsNavigator.tsx
@@ -10,6 +10,7 @@ import MyRecordsScreen from '../screens/MyRecordsScreen';
 import NfcScannerScreen from '../screens/NfcScannerScreen';
 import TransicionScreen from '../screens/TransicionScreen';
 import TymeEntryScreen from '../screens/TymeEntryScreen';
+import CrearTrabajadorScreen from '../screens/CrearTrabajadorScreen';
 import type { HomeStackParamList } from '../types/navigation';
 import { TabsParamList } from '../types/navigation';
 
@@ -24,6 +25,7 @@ function HomeStackNavigator() {
       <HomeStack.Screen name="DetalleTrabajador" component={DetalleTrabajadorScreen} />
       <HomeStack.Screen name="TimeEntry" component={TymeEntryScreen} />
       <HomeStack.Screen name="MisRegistros" component={MyRecordsScreen} />
+      <HomeStack.Screen name="CrearTrabajador" component={CrearTrabajadorScreen} />
     </HomeStack.Navigator>
   );
 }

--- a/src/screens/CrearTrabajadorScreen.tsx
+++ b/src/screens/CrearTrabajadorScreen.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  Alert,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { HomeStackParamList } from '../types/navigation';
+import { crearTrabajador } from '../services/trabajadorService';
+import styles from '../styles/crearTrabajadorStyles';
+
+type NavProp = NativeStackNavigationProp<HomeStackParamList, 'CrearTrabajador'>;
+
+export default function CrearTrabajadorScreen() {
+  const navigation = useNavigation<NavProp>();
+  const [nombres, setNombres] = useState('');
+  const [direccion, setDireccion] = useState('');
+  const [contacto, setContacto] = useState('');
+  const [rol, setRol] = useState('');
+  const [pulseraUuid, setPulseraUuid] = useState('');
+
+  const isValid =
+    nombres.trim() && direccion.trim() && contacto.trim() && rol.trim() && pulseraUuid.trim();
+
+  const handleSubmit = async () => {
+    try {
+      await crearTrabajador({
+        nombres,
+        direccion,
+        contacto,
+        rol,
+        pulsera_uuid: pulseraUuid,
+      });
+      Alert.alert('Éxito', 'Trabajador creado correctamente', [
+        { text: 'OK', onPress: () => navigation.navigate('Inicio') },
+      ]);
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'No se pudo crear el trabajador');
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView
+        contentContainerStyle={styles.container}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.title}>Registrar Trabajador</Text>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            placeholder="Nombres"
+            value={nombres}
+            onChangeText={setNombres}
+            placeholderTextColor="#999"
+          />
+        </View>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            placeholder="Dirección"
+            value={direccion}
+            onChangeText={setDireccion}
+            placeholderTextColor="#999"
+          />
+        </View>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            placeholder="Contacto"
+            value={contacto}
+            onChangeText={setContacto}
+            keyboardType="phone-pad"
+            placeholderTextColor="#999"
+          />
+        </View>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            placeholder="Rol"
+            value={rol}
+            onChangeText={setRol}
+            placeholderTextColor="#999"
+          />
+        </View>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            placeholder="Pulsera UUID"
+            value={pulseraUuid}
+            onChangeText={setPulseraUuid}
+            placeholderTextColor="#999"
+          />
+        </View>
+
+        <TouchableOpacity
+          style={[styles.button, !isValid && styles.buttonDisabled]}
+          disabled={!isValid}
+          onPress={handleSubmit}
+        >
+          <Text style={styles.buttonText}>Crear Trabajador</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/src/screens/NfcScannerScreen.tsx
+++ b/src/screens/NfcScannerScreen.tsx
@@ -58,7 +58,15 @@ export default function NfcScannerScreen() {
           navigation.navigate('TimeEntry', { trabajador });
           break;
         case 'REGISTRAR':
-          navigation.navigate('TimeEntry', { trabajador });
+          if (trabajador.rol === 'supervisor') {
+            navigation.navigate('CrearTrabajador');
+          } else {
+            Alert.alert(
+              'Permiso denegado',
+              'No tienes permisos para registrar trabajadores',
+              [{ text: 'OK', onPress: () => navigation.navigate('Inicio') }]
+            );
+          }
           break;
         case 'MIS_REGISTROS':
           navigation.navigate('MisRegistros', { trabajador });

--- a/src/services/trabajadorService.ts
+++ b/src/services/trabajadorService.ts
@@ -22,3 +22,18 @@ export const getTrabajadorPorPulsera = async (
     throw new Error('No se encontró el trabajador');
   }
 };
+
+export interface CrearTrabajadorData {
+  nombres: string;
+  direccion: string;
+  contacto: string;
+  rol: string;
+  pulsera_uuid: string;
+}
+
+export const crearTrabajador = async (
+  data: CrearTrabajadorData
+): Promise<Trabajador> => {
+  const resp = await api.post<Trabajador>('/trabajadores', data);
+  return resp.data;
+};

--- a/src/styles/crearTrabajadorStyles.ts
+++ b/src/styles/crearTrabajadorStyles.ts
@@ -1,0 +1,49 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#7A32C2',
+    marginBottom: 24,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    marginBottom: 16,
+    width: '100%',
+    height: 48,
+  },
+  input: {
+    flex: 1,
+    fontSize: 16,
+    color: '#333',
+  },
+  button: {
+    backgroundColor: '#7A32C2',
+    paddingVertical: 14,
+    borderRadius: 8,
+    width: '100%',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  buttonDisabled: {
+    backgroundColor: '#ccc',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -5,6 +5,7 @@ export type RootStackParamList = {
   DetalleTrabajador: { trabajador: any };
   TimeEntry: { trabajador: any };
   MisRegistros: { trabajador: any };  // Recibe el objeto trabajador
+  CrearTrabajador: undefined;
 };
 
 // Tabs navigator parameters
@@ -21,4 +22,5 @@ export type HomeStackParamList = {
   DetalleTrabajador: { trabajador: any };
   TimeEntry: { trabajador: any };
   MisRegistros: { trabajador: any };    // También aquí recibe params
+  CrearTrabajador: undefined;
 };


### PR DESCRIPTION
## Summary
- create service and styles for registering workers
- add new screen `CrearTrabajadorScreen`
- register screen in navigation stacks
- gate registration action behind supervisor role

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee0c9b230832f89d7d8d5e47cd93d