### PR TITLE
Add NFC bracelet assign screen

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -10,6 +10,7 @@ import TransicionScreen from '../screens/TransicionScreen';
 import DetalleTrabajadorScreen from '../screens/DetalleTrabajadorScreen';
 import TimeEntryScreen from '../screens/TymeEntryScreen';
 import CrearTrabajadorScreen from '../screens/CrearTrabajadorScreen';
+import AsignarPulseraScreen from '../screens/AsignarPulseraScreen';
 import { useAuth } from '../contexts/AuthContext';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -45,6 +46,10 @@ export default function RootNavigator() {
           <Stack.Screen
             name="CrearTrabajador"
             component={CrearTrabajadorScreen}
+          />
+          <Stack.Screen
+            name="AsignarPulsera"
+            component={AsignarPulseraScreen}
           />
         </>
       ) : (

--- a/src/navigation/TabsNavigator.tsx
+++ b/src/navigation/TabsNavigator.tsx
@@ -11,6 +11,7 @@ import NfcScannerScreen from '../screens/NfcScannerScreen';
 import TransicionScreen from '../screens/TransicionScreen';
 import TymeEntryScreen from '../screens/TymeEntryScreen';
 import CrearTrabajadorScreen from '../screens/CrearTrabajadorScreen';
+import AsignarPulseraScreen from '../screens/AsignarPulseraScreen';
 import type { HomeStackParamList } from '../types/navigation';
 import { TabsParamList } from '../types/navigation';
 
@@ -26,6 +27,7 @@ function HomeStackNavigator() {
       <HomeStack.Screen name="TimeEntry" component={TymeEntryScreen} />
       <HomeStack.Screen name="MisRegistros" component={MyRecordsScreen} />
       <HomeStack.Screen name="CrearTrabajador" component={CrearTrabajadorScreen} />
+      <HomeStack.Screen name="AsignarPulsera" component={AsignarPulseraScreen} />
     </HomeStack.Navigator>
   );
 }

--- a/src/screens/AsignarPulseraScreen.tsx
+++ b/src/screens/AsignarPulseraScreen.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, Alert } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { HomeStackParamList } from '../types/navigation';
+import { crearTrabajador } from '../services/trabajadorService';
+import styles from '../styles/asignarPulseraStyles';
+
+// Tipo para las props de navegación
+export type AsignarPulseraProps = NativeStackScreenProps<
+  HomeStackParamList,
+  'AsignarPulsera'
+>;
+
+export default function AsignarPulseraScreen({
+  navigation,
+  route,
+}: AsignarPulseraProps) {
+  const { trabajadorData } = route.params;
+  const [uuid, setUuid] = useState('');
+
+  useEffect(() => {
+    setUuid(generateUUID());
+  }, []);
+
+  const handleConfirm = async () => {
+    try {
+      await crearTrabajador({ ...trabajadorData, pulsera_uuid: uuid });
+      Alert.alert('Éxito', `Pulsera seteada con UUID:\n${uuid}`, [
+        { text: 'OK', onPress: () => navigation.navigate('Inicio') },
+      ]);
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'No se pudo asignar la pulsera');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Pulsera configurada</Text>
+      <Text style={styles.uuid}>{uuid}</Text>
+      <TouchableOpacity style={styles.button} onPress={handleConfirm}>
+        <Text style={styles.buttonText}>Aceptar</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function generateUUID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/src/screens/CrearTrabajadorScreen.tsx
+++ b/src/screens/CrearTrabajadorScreen.tsx
@@ -12,7 +12,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { HomeStackParamList } from '../types/navigation';
-import { crearTrabajador } from '../services/trabajadorService';
+import type { CrearTrabajadorData } from '../services/trabajadorService';
 import styles from '../styles/crearTrabajadorStyles';
 
 type NavProp = NativeStackNavigationProp<HomeStackParamList, 'CrearTrabajador'>;
@@ -23,26 +23,16 @@ export default function CrearTrabajadorScreen() {
   const [direccion, setDireccion] = useState('');
   const [contacto, setContacto] = useState('');
   const [rol, setRol] = useState('');
-  const [pulseraUuid, setPulseraUuid] = useState('');
+  const isValid = nombres.trim() && direccion.trim() && contacto.trim() && rol.trim();
 
-  const isValid =
-    nombres.trim() && direccion.trim() && contacto.trim() && rol.trim() && pulseraUuid.trim();
-
-  const handleSubmit = async () => {
-    try {
-      await crearTrabajador({
-        nombres,
-        direccion,
-        contacto,
-        rol,
-        pulsera_uuid: pulseraUuid,
-      });
-      Alert.alert('Éxito', 'Trabajador creado correctamente', [
-        { text: 'OK', onPress: () => navigation.navigate('Inicio') },
-      ]);
-    } catch (err: any) {
-      Alert.alert('Error', err.message || 'No se pudo crear el trabajador');
-    }
+  const handleSubmit = () => {
+    const data: Omit<CrearTrabajadorData, 'pulsera_uuid'> = {
+      nombres,
+      direccion,
+      contacto,
+      rol,
+    };
+    navigation.navigate('AsignarPulsera', { trabajadorData: data });
   };
 
   return (
@@ -97,15 +87,7 @@ export default function CrearTrabajadorScreen() {
           />
         </View>
 
-        <View style={styles.inputContainer}>
-          <TextInput
-            style={styles.input}
-            placeholder="Pulsera UUID"
-            value={pulseraUuid}
-            onChangeText={setPulseraUuid}
-            placeholderTextColor="#999"
-          />
-        </View>
+
 
         <TouchableOpacity
           style={[styles.button, !isValid && styles.buttonDisabled]}

--- a/src/styles/asignarPulseraStyles.ts
+++ b/src/styles/asignarPulseraStyles.ts
@@ -1,0 +1,33 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#7A32C2',
+    marginBottom: 16,
+  },
+  uuid: {
+    fontSize: 20,
+    color: '#333',
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: '#7A32C2',
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -6,6 +6,9 @@ export type RootStackParamList = {
   TimeEntry: { trabajador: any };
   MisRegistros: { trabajador: any };  // Recibe el objeto trabajador
   CrearTrabajador: undefined;
+  AsignarPulsera: {
+    trabajadorData: Omit<import('../services/trabajadorService').CrearTrabajadorData, 'pulsera_uuid'>;
+  };
 };
 
 // Tabs navigator parameters
@@ -23,4 +26,7 @@ export type HomeStackParamList = {
   TimeEntry: { trabajador: any };
   MisRegistros: { trabajador: any };    // También aquí recibe params
   CrearTrabajador: undefined;
+  AsignarPulsera: {
+    trabajadorData: Omit<import('../services/trabajadorService').CrearTrabajadorData, 'pulsera_uuid'>;
+  };
 };


### PR DESCRIPTION
## Summary
- add `AsignarPulseraScreen` for assigning random UUIDs to NFC bracelets
- store UUID and create worker once confirmed
- wire new screen into navigators and navigation types
- update worker creation flow to use the new screen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68509dabb420832f98de31e3299f3010