### PR TITLE
Update token error regex

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -41,7 +41,7 @@ httpClient.interceptors.response.use(
     const tokenError =
       (status === 401 || status === 403) &&
       typeof msg === 'string' &&
-      /token.*(expirado|expired|inv\u00e1lido)/i.test(msg);
+      /(token|jwt).*?(expirad|expired|inv\u00e1lido)/i.test(msg);
 
     if (tokenError && !originalReq._retry) {
       originalReq._retry = true;


### PR DESCRIPTION
## Summary
- expand token error detection regex to include 'jwt'
- keep `_retry` flag so refresh only triggers once

## Testing
- `npm run lint --silent` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685335dac6b0832fb49cd096924c952f