### PR TITLE
Add skipAuth request config

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,5 @@
 import { httpClient } from './httpClient';
+import type { AuthRequestConfig } from './api';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export interface LoginResponse {
@@ -31,7 +32,8 @@ export const refreshAccessToken = async (): Promise<string> => {
   if (!stored) throw new Error('No hay refreshToken disponible');
   const { data } = await httpClient.post<RefreshResponse>(
     '/auth/refresh',
-    { refreshToken: stored }
+    { refreshToken: stored },
+    { skipAuth: true } as AuthRequestConfig
   );
   await AsyncStorage.setItem('accessToken', data.accessToken);
   return data.accessToken;


### PR DESCRIPTION
## Summary
- allow requests to skip auth headers via `skipAuth` option
- use `skipAuth` when refreshing tokens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685336b98e3c832fa8575546fe129759