### PR TITLE
Implement modal feedback for worker creation

### DIFF
--- a/src/screens/CrearTrabajadorScreen.tsx
+++ b/src/screens/CrearTrabajadorScreen.tsx
@@ -1,10 +1,11 @@
+import { Feather } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useEffect, useRef, useState } from 'react';
 import {
   Animated,
-  Modal,
   KeyboardAvoidingView,
+  Modal,
   Platform,
   ScrollView,
   Text,
@@ -12,7 +13,6 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { Feather } from '@expo/vector-icons';
 import {
   actualizarEstado,
   consultarEstado,
@@ -90,7 +90,7 @@ export default function CrearTrabajadorScreen() {
       setShowModal(true);
       setTimeout(() => {
         setShowModal(false);
-        navigation.navigate('Inicio');
+        navigation.navigate('NfcScanner');
       }, 2500);
     } catch (err: any) {
       setModalMessage(err.message || 'No se pudo crear el trabajador');


### PR DESCRIPTION
## Summary
- add custom modal to display messages when registering workers
- show modal on wristband scan and on creation result

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536c39e3d4832fa0d1b27aed3c3c3d