### PR TITLE
Refactor feedback modal into reusable component

### DIFF
--- a/components/FeedbackModal.tsx
+++ b/components/FeedbackModal.tsx
@@ -1,7 +1,7 @@
+import { Feather } from '@expo/vector-icons';
 import React, { useEffect, useRef } from 'react';
 import { Animated, Modal, Text, View } from 'react-native';
-import { Feather } from '@expo/vector-icons';
-import modalStyles from '@/styles/modalStyles';
+import modalStyles from '../src/styles/modalStyles';
 
 type FeedbackModalProps = {
   visible: boolean;

--- a/components/FeedbackModal.tsx
+++ b/components/FeedbackModal.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Modal, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import modalStyles from '@/styles/modalStyles';
+
+type FeedbackModalProps = {
+  visible: boolean;
+  message: string;
+};
+
+export default function FeedbackModal({ visible, message }: FeedbackModalProps) {
+  const scaleAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.spring(scaleAnim, { toValue: 1, friction: 6, useNativeDriver: true }).start();
+    } else {
+      scaleAnim.setValue(0);
+    }
+  }, [visible, scaleAnim]);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <Animated.View style={[modalStyles.content, { transform: [{ scale: scaleAnim }] }]}>
+          <Feather name="alert-triangle" size={80} color="#FFA500" style={modalStyles.icon} />
+          <Text style={modalStyles.title}>¡Atención!</Text>
+          <Text style={modalStyles.message}>{message}</Text>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/screens/CrearTrabajadorScreen.tsx
+++ b/src/screens/CrearTrabajadorScreen.tsx
@@ -1,11 +1,9 @@
 import { Feather } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import {
-  Animated,
   KeyboardAvoidingView,
-  Modal,
   Platform,
   ScrollView,
   Text,
@@ -19,7 +17,7 @@ import {
 } from '../services/pulseraService';
 import { crearTrabajador } from '../services/trabajadorService';
 import styles from '../styles/crearTrabajadorStyles';
-import modalStyles from '../styles/tymeEntryModalStyles';
+import FeedbackModal from '@/components/FeedbackModal';
 import type { HomeStackParamList } from '../types/navigation';
 
 type NavProp = NativeStackNavigationProp<HomeStackParamList, 'CrearTrabajador'>;
@@ -35,15 +33,6 @@ export default function CrearTrabajadorScreen() {
   // Estado para modal de feedback
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
-  const scaleAnim = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    if (showModal) {
-      Animated.spring(scaleAnim, { toValue: 1, friction: 6, useNativeDriver: true }).start();
-    } else {
-      scaleAnim.setValue(0);
-    }
-  }, [showModal, scaleAnim]);
 
   const handleScanPulsera = async () => {
     try {
@@ -175,15 +164,7 @@ export default function CrearTrabajadorScreen() {
           <Text style={styles.buttonText}>Crear Trabajador</Text>
         </TouchableOpacity>
       </ScrollView>
-      <Modal visible={showModal} transparent animationType="fade">
-        <View style={modalStyles.overlay}>
-          <Animated.View style={[modalStyles.content, { transform: [{ scale: scaleAnim }] }]}>
-            <Feather name="alert-triangle" size={80} color="#FFA500" />
-            <Text style={modalStyles.title}>¡Atención!</Text>
-            <Text style={modalStyles.message}>{modalMessage}</Text>
-          </Animated.View>
-        </View>
-      </Modal>
+      <FeedbackModal visible={showModal} message={modalMessage} />
     </KeyboardAvoidingView>
   );
 }

--- a/src/screens/CrearTrabajadorScreen.tsx
+++ b/src/screens/CrearTrabajadorScreen.tsx
@@ -17,7 +17,7 @@ import {
 } from '../services/pulseraService';
 import { crearTrabajador } from '../services/trabajadorService';
 import styles from '../styles/crearTrabajadorStyles';
-import FeedbackModal from '@/components/FeedbackModal';
+import FeedbackModal from '../../components/FeedbackModal';
 import type { HomeStackParamList } from '../types/navigation';
 
 type NavProp = NativeStackNavigationProp<HomeStackParamList, 'CrearTrabajador'>;

--- a/src/screens/TymeEntryScreen.tsx
+++ b/src/screens/TymeEntryScreen.tsx
@@ -20,7 +20,7 @@ import {
   TipoAsistencia,
 } from '../services/tymeEntryService';
 import styles from '../styles/tymeEntryStyles';
-import FeedbackModal from '@/components/FeedbackModal';
+import FeedbackModal from '../../components/FeedbackModal';
 import type { HomeStackParamList } from '../types/navigation';
 
 // Tipos de navegación

--- a/src/screens/TymeEntryScreen.tsx
+++ b/src/screens/TymeEntryScreen.tsx
@@ -5,11 +5,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { RouteProp } from '@react-navigation/native';
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
-  Animated,
-  Modal,
   Text,
   TouchableOpacity,
   View,
@@ -21,8 +19,8 @@ import {
   postAsistencia,
   TipoAsistencia,
 } from '../services/tymeEntryService';
-import modalStyles from '../styles/tymeEntryModalStyles';
 import styles from '../styles/tymeEntryStyles';
+import FeedbackModal from '@/components/FeedbackModal';
 import type { HomeStackParamList } from '../types/navigation';
 
 // Tipos de navegación
@@ -82,16 +80,6 @@ export default function TimeEntryScreen() {
   // Modal de feedback
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
-  const scaleAnim = useRef(new Animated.Value(0)).current;
-
-  // Animación del modal
-  useEffect(() => {
-    if (showModal) {
-      Animated.spring(scaleAnim, { toValue: 1, friction: 6, useNativeDriver: true }).start();
-    } else {
-      scaleAnim.setValue(0);
-    }
-  }, [showModal]);
 
   // Carga estado de asistencias y ajusta botones
   const loadCurrent = useCallback(async (skipCompleteCheck = false) => {
@@ -163,15 +151,7 @@ export default function TimeEntryScreen() {
           <Text style={styles.buttonText}>{formatTipo(tipo)}</Text>
         </TouchableOpacity>
       ))}
-      <Modal visible={showModal} transparent animationType="fade">
-        <View style={modalStyles.overlay}>
-          <Animated.View style={[modalStyles.content, { transform: [{ scale: scaleAnim }] }]}> 
-            <Feather name="alert-triangle" size={80} color="#FFA500" />
-            <Text style={modalStyles.title}>¡Atención!</Text>
-            <Text style={modalStyles.message}>{modalMessage}</Text>
-          </Animated.View>
-        </View>
-      </Modal>
+      <FeedbackModal visible={showModal} message={modalMessage} />
     </View>
   );
 }

--- a/src/styles/modalStyles.ts
+++ b/src/styles/modalStyles.ts
@@ -1,4 +1,4 @@
-// src/styles/timeEntryModalStyles.ts
+// src/styles/modalStyles.ts
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({


### PR DESCRIPTION
## Summary
- extract modal code into `FeedbackModal` component
- replace inline modal usage in screens
- rename `tymeEntryModalStyles` to `modalStyles`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536e82f9b8832faf4e3eaaeef4ca30