### PR TITLE
Allow custom title and icon in feedback modal

### DIFF
--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,40 +1,48 @@
-import React from 'react';
-import { Modal, View, Text, StyleSheet } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import React, { useEffect, useRef } from 'react';
+import { Animated, Modal, Text, View } from 'react-native';
+import modalStyles from '../styles/modalStyles';
 
-interface FeedbackModalProps {
+export type FeedbackModalProps = {
   visible: boolean;
   message: string;
+  /** Texto mostrado como título del modal */
+  title?: string;
+  /** Icono de Feather a mostrar en el encabezado */
+  iconName?: React.ComponentProps<typeof Feather>['name'];
+};
+
+export default function FeedbackModal({
+  visible,
+  message,
+  title = '¡Atención!',
+  iconName = 'alert-triangle',
+}: FeedbackModalProps) {
+  const scaleAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.spring(scaleAnim, { toValue: 1, friction: 6, useNativeDriver: true }).start();
+    } else {
+      scaleAnim.setValue(0);
+    }
+  }, [visible, scaleAnim]);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <Animated.View style={[modalStyles.content, { transform: [{ scale: scaleAnim }] }]}>
+          <Feather
+            name={iconName}
+            size={80}
+            color="#FFA500"
+            style={modalStyles.icon}
+          />
+          <Text style={modalStyles.title}>{title}</Text>
+          <Text style={modalStyles.message}>{message}</Text>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
 }
 
-const FeedbackModal: React.FC<FeedbackModalProps> = ({ visible, message }) => (
-  <Modal transparent animationType="fade" visible={visible}>
-    <View style={styles.overlay}>
-      <View style={styles.modal}>
-        <Text style={styles.text}>{message}</Text>
-      </View>
-    </View>
-  </Modal>
-);
-
-const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  modal: {
-    backgroundColor: '#fff',
-    borderRadius: 10,
-    padding: 24,
-    minWidth: 200,
-    alignItems: 'center',
-  },
-  text: {
-    fontSize: 16,
-    color: '#333',
-    textAlign: 'center',
-  },
-});
-
-export default FeedbackModal;

--- a/src/screens/CrearTrabajadorScreen.tsx
+++ b/src/screens/CrearTrabajadorScreen.tsx
@@ -33,21 +33,29 @@ export default function CrearTrabajadorScreen() {
   // Estado para modal de feedback
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+  const [modalTitle, setModalTitle] = useState('');
+  const [modalIcon, setModalIcon] = useState<React.ComponentProps<typeof Feather>['name']>('alert-triangle');
 
   const handleScanPulsera = async () => {
     try {
       const uuid = 'PULS016';
       await consultarEstado(uuid);
+      setModalTitle('Pulsera activa');
+      setModalIcon('alert-circle');
       setModalMessage('Pulsera activa\nUtilice otra pulsera');
       setShowModal(true);
       setTimeout(() => setShowModal(false), 2500);
     } catch (err: any) {
       if (err.response && err.response.status === 403) {
         setPulseraUuid('PULS016');
+        setModalTitle('Pulsera lista');
+        setModalIcon('check-circle');
         setModalMessage('Pulsera lista\nPulsera asignada al usuario');
         setShowModal(true);
         setTimeout(() => setShowModal(false), 2500);
       } else {
+        setModalTitle('Error');
+        setModalIcon('alert-triangle');
         setModalMessage('Error\nNo se pudo verificar la pulsera');
         setShowModal(true);
         setTimeout(() => setShowModal(false), 2500);
@@ -75,6 +83,8 @@ export default function CrearTrabajadorScreen() {
         pulsera_uuid: pulseraUuid,
       });
       await actualizarEstado(pulseraUuid, 'activa');
+      setModalTitle('Éxito');
+      setModalIcon('check-circle');
       setModalMessage('Trabajador creado correctamente');
       setShowModal(true);
       setTimeout(() => {
@@ -82,6 +92,8 @@ export default function CrearTrabajadorScreen() {
         navigation.navigate('NfcScanner');
       }, 2500);
     } catch (err: any) {
+      setModalTitle('Error');
+      setModalIcon('alert-triangle');
       setModalMessage(err.message || 'No se pudo crear el trabajador');
       setShowModal(true);
       setTimeout(() => setShowModal(false), 2500);
@@ -164,7 +176,12 @@ export default function CrearTrabajadorScreen() {
           <Text style={styles.buttonText}>Crear Trabajador</Text>
         </TouchableOpacity>
       </ScrollView>
-      <FeedbackModal visible={showModal} message={modalMessage} />
+      <FeedbackModal
+        visible={showModal}
+        message={modalMessage}
+        title={modalTitle}
+        iconName={modalIcon}
+      />
     </KeyboardAvoidingView>
   );
 }

--- a/src/screens/TymeEntryScreen.tsx
+++ b/src/screens/TymeEntryScreen.tsx
@@ -80,6 +80,8 @@ export default function TimeEntryScreen() {
   // Modal de feedback
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+  const [modalTitle, setModalTitle] = useState('');
+  const [modalIcon, setModalIcon] = useState<React.ComponentProps<typeof Feather>['name']>('alert-triangle');
 
   // Carga estado de asistencias y ajusta botones
   const loadCurrent = useCallback(async (skipCompleteCheck = false) => {
@@ -96,6 +98,8 @@ export default function TimeEntryScreen() {
 
       // Si ya registró todo y no se omite la verificación, mostramos mensaje y redirigimos
       if (!skipCompleteCheck && Object.values(next).every(v => !v)) {
+        setModalTitle('Asistencia completa');
+        setModalIcon('check-circle');
         setModalMessage('Ya tienes registrada tu asistencia del día de hoy.\n¡Hasta mañana!');
         setShowModal(true);
         setTimeout(() => {
@@ -121,6 +125,8 @@ export default function TimeEntryScreen() {
       let msg = `Se marcó ${formatTipo(tipo)}\na las ${hora}`;
       if (tipo === 'salida') msg += '\n¡Has finalizado el día! Hasta mañana!';
 
+      setModalTitle('Registro exitoso');
+      setModalIcon('check-circle');
       setModalMessage(msg);
       setShowModal(true);
       await loadCurrent(true);
@@ -151,7 +157,12 @@ export default function TimeEntryScreen() {
           <Text style={styles.buttonText}>{formatTipo(tipo)}</Text>
         </TouchableOpacity>
       ))}
-      <FeedbackModal visible={showModal} message={modalMessage} />
+      <FeedbackModal
+        visible={showModal}
+        message={modalMessage}
+        title={modalTitle}
+        iconName={modalIcon}
+      />
     </View>
   );
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,5 +1,5 @@
-import { httpClient } from './httpClient';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { httpClient } from './httpClient';
 
 export interface LoginResponse {
   accessToken: string;
@@ -40,4 +40,4 @@ export const refreshAccessToken = async (): Promise<string> => {
 export const clearTokens = () =>
   AsyncStorage.multiRemove(['accessToken', 'refreshToken']);
 
-// Elimina TODO import api from './api'
+


### PR DESCRIPTION
## Summary
- enhance feedback modal component to support custom title and icon
- use new modal props in CrearTrabajadorScreen and TymeEntryScreen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853795b2580832f9d51f60bd8a42681